### PR TITLE
223 - Expose metallb lb outside the network

### DIFF
--- a/metallb/gateway.yaml
+++ b/metallb/gateway.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: leapfrogai
+  namespace: istio-system
+spec:
+  selector:
+    app: tenant-ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 8080
+      protocol: HTTP
+    tls:
+      httpsRedirect: true
+  - hosts:
+    - '*'
+    port:
+      name: https
+      number: 8443
+      protocol: HTTPS
+    tls:
+      credentialName: tenant-cert
+      minProtocolVersion: TLSV1_3
+      mode: SIMPLE

--- a/metallb/service.yaml
+++ b/metallb/service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/ip-allocated-from-pool: default
+  name: leapfrogai
+  namespace: istio-system
+spec:
+  allocateLoadBalancerNodePorts: true
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: status-port
+    nodePort: 30248
+    port: 15021
+    protocol: TCP
+    targetPort: 15021
+  - name: http2
+    nodePort: 32386
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: https
+    nodePort: 30535
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: tenant-ingressgateway
+    istio: ingressgateway
+  sessionAffinity: None
+  type: LoadBalancer

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -36,3 +36,11 @@ components:
     images:
       - "ghcr.io/defenseunicorns/leapfrogai-api:0.4.2"
       - "registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.23.3"
+  - name: metallb-config
+    required: false
+    description: "Creates metallb tenant ingresses for the cluster"
+    manifests:
+      - name: metallb-config
+        files:
+          - metallb/gateway.yaml
+          - metallb/service.yaml


### PR DESCRIPTION
Adds Kustomizations that will create static nodeports that can be exposed by the k3d lb