### PR TITLE
232 - Updates API to reference v0.4.2

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -4,12 +4,12 @@ kind: ZarfPackageConfig
 metadata:
   name: leapfrogai-api
   description: "LeapfrogAI"
-  version: 0.4.1
+  version: 0.4.2
   architecture: amd64
 
 constants:
   - name: LEAPFROGAI_API_VERSION
-    value: "0.4.1"
+    value: "0.4.2"
   - name: KIWIGRID_VERSION
     value: "1.23.3"
 
@@ -30,9 +30,9 @@ components:
     - name: leapfrogai
       namespace: leapfrogai
       localPath: chart
-      version: 0.4.1
+      version: 0.4.2
       valuesFiles:
         - "lfai-values.yaml"
     images:
-      - "ghcr.io/defenseunicorns/leapfrogai/leapfrogai-api:0.4.1"
+      - "ghcr.io/defenseunicorns/leapfrogai-api:0.4.2"
       - "registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.23.3"


### PR DESCRIPTION
- Updates version to reference new 0.4.2 image so that Zarf does not complain at build/deploy time.