### PR TITLE
Deconflict multiple endpoint k8s

### DIFF
--- a/chart/templates/vs.yaml
+++ b/chart/templates/vs.yaml
@@ -7,7 +7,7 @@ spec:
   gateways:
   - istio-system/{{ .Values.istio.gateway }}
   hosts:
-  - {{ .Values.domain }}
+  - "*"
   http:
    - match:
      - uri:

--- a/chart/templates/vs.yaml
+++ b/chart/templates/vs.yaml
@@ -7,7 +7,7 @@ spec:
   gateways:
   - istio-system/{{ .Values.istio.gateway }}
   hosts:
-  - leapfrogai.{{ .Values.domain }}
+  - {{ .Values.domain }}
   http:
    - match:
      - uri:

--- a/chart/templates/vs.yaml
+++ b/chart/templates/vs.yaml
@@ -9,10 +9,20 @@ spec:
   hosts:
   - leapfrogai.{{ .Values.domain }}
   http:
-  - route:
-    - destination:
+   - match:
+     - uri:
+         prefix: "###ZARF_VAR_PREFIX###/"
+     rewrite:
+       uri: "/"
+     route:
+     - destination:
         host: api
         port:
           number: 8080
+   - match:
+       - uri:
+           prefix: "###ZARF_VAR_PREFIX###"
+     redirect:
+       uri: "###ZARF_VAR_PREFIX###/"
 {{- end }}
 ---

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,4 @@
-domain: *
+domain: "*"
 
 image: 
   lfaiAPITag: ###ZARF_CONST_LEAPFROGAI_API_VERSION###

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,4 @@
-domain: bigbang.dev
+domain: *
 
 image: 
   lfaiAPITag: ###ZARF_CONST_LEAPFROGAI_API_VERSION###
@@ -6,7 +6,7 @@ image:
 
 istio:
   enabled: false
-  gateway: tenant
+  gateway: leapfrogai
   injection: disabled
 
 api:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,3 @@
-domain: "*"
-
 image: 
   lfaiAPITag: ###ZARF_CONST_LEAPFROGAI_API_VERSION###
   kiwigridTag: 1.23.3

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,11 +17,11 @@ variables:
   - name: ISTIO_ENABLED
     default: "false"
   - name: ISTIO_GATEWAY
-    default: "tenant"
+    default: "leapfrogai"
   - name: ISTIO_INJECTION
     default: "disabled"
   - name: DOMAIN
-    default: "bigbang.dev"
+    default: "*"
   - name: PREFIX
     description: Prefix for requests to the application
     default: ""

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -20,8 +20,6 @@ variables:
     default: "leapfrogai"
   - name: ISTIO_INJECTION
     default: "disabled"
-  - name: DOMAIN
-    default: "*"
   - name: PREFIX
     description: Prefix for requests to the application
     default: ""

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -22,6 +22,11 @@ variables:
     default: "disabled"
   - name: DOMAIN
     default: "bigbang.dev"
+  - name: PREFIX
+    description: Prefix for requests to the application
+    default: ""
+    prompt: true
+    sensitive: false
 
 components:
   - name: leapfrogai


### PR DESCRIPTION
Adds support for specifying a prefix to the VirtualService so that the same IP can share multiple applications by default