### PR TITLE
add security context to match the base image

### DIFF
--- a/chart/templates/api/deployment.yaml
+++ b/chart/templates/api/deployment.yaml
@@ -56,6 +56,10 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
           volumeMounts:
           - name: api-model
             mountPath: /config


### PR DESCRIPTION
Pepr by default will setup the security context to run as user and group 1000 if it's not set. This sets it to match what the Chainguard-derived image uses, which fixes it with UDS Core.