### PR TITLE
37 config watch fails to pick up new backends in k8s cluster

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,17 +6,18 @@ from backends.openai.routes import *
 from contextlib import asynccontextmanager
 from utils import get_model_config
 import asyncio
+import logging
 
 
 # handle startup & shutdown tasks
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # startup
-    print("Starting to watch for configs")
+    logging.info("Starting to watch for configs")
     asyncio.create_task(get_model_config().watch_and_load_configs())
     yield
     # shutdown
-    print("Clearing model configs")
+    logging.info("Clearing model configs")
     asyncio.create_task(get_model_config().clear_all_models())
 
 

--- a/main.py
+++ b/main.py
@@ -17,9 +17,15 @@ async def healthz():
 async def models():
     return get_model_config()
 
-
 @app.on_event('startup')
 async def watch_for_configs():
+    print("Starting to watch for configs")
     asyncio.create_task(get_model_config().watch_and_load_configs())
+
+@app.on_event('shutdown')
+async def clear_configs():
+    print('Clearing model configs')
+    asyncio.create_task(get_model_config().clear_all_models())
+
 
 app.include_router(openai_router)

--- a/main.py
+++ b/main.py
@@ -3,10 +3,24 @@ from fastapi import FastAPI
 # We need to import all the functions in these files so the router decorator gets processed
 from backends.openai import router as openai_router
 from backends.openai.routes import *
+from contextlib import asynccontextmanager
 from utils import get_model_config
 import asyncio
 
-app = FastAPI()
+
+# handle startup & shutdown tasks
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # startup
+    print("Starting to watch for configs")
+    asyncio.create_task(get_model_config().watch_and_load_configs())
+    yield
+    # shutdown
+    print("Clearing model configs")
+    asyncio.create_task(get_model_config().clear_all_models())
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 # super simple healthz check
@@ -18,18 +32,6 @@ async def healthz():
 @app.get("/models")
 async def models():
     return get_model_config()
-
-
-@app.on_event("startup")
-async def watch_for_configs():
-    print("Starting to watch for configs")
-    asyncio.create_task(get_model_config().watch_and_load_configs())
-
-
-@app.on_event("shutdown")
-async def clear_configs():
-    print("Clearing model configs")
-    asyncio.create_task(get_model_config().clear_all_models())
 
 
 app.include_router(openai_router)

--- a/main.py
+++ b/main.py
@@ -8,23 +8,27 @@ import asyncio
 
 app = FastAPI()
 
+
 # super simple healthz check
 @app.get("/healthz")
 async def healthz():
     return {"status": "ok"}
 
+
 @app.get("/models")
 async def models():
     return get_model_config()
 
-@app.on_event('startup')
+
+@app.on_event("startup")
 async def watch_for_configs():
     print("Starting to watch for configs")
     asyncio.create_task(get_model_config().watch_and_load_configs())
 
-@app.on_event('shutdown')
+
+@app.on_event("shutdown")
 async def clear_configs():
-    print('Clearing model configs')
+    print("Clearing model configs")
     asyncio.create_task(get_model_config().clear_all_models())
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,8 @@ def test_config_load():
     with TestClient(app) as client:
         response = client.get("/models")
         assert response.status_code == 200
-        assert response.json() == {"models":  {'repeater': {'backend': 'localhost:50051', 'name': 'repeater'}}}
+        assert response.json() == {'config_sources': {'test-config.yaml': ['repeater']},
+            "models":  {'repeater': {'backend': 'localhost:50051', 'name': 'repeater'}}}
 
 
 def test_routes():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,10 @@
 from fastapi.testclient import TestClient
-from fastapi import FastAPI
 from main import app
 import backends.openai.types as lfai_types
 import json
 import os
 import pytest
 import time
-import yaml
 
 os.environ["LFAI_CONFIG_FILENAME"] = "test-config.yaml"
 os.environ["LFAI_CONFIG_PATH"] = os.path.join(os.path.dirname(__file__), "fixtures")
@@ -16,41 +14,46 @@ def test_config_load():
     with TestClient(app) as client:
         response = client.get("/models")
         assert response.status_code == 200
-        assert response.json() == {'config_sources': {'test-config.yaml': ['repeater']},
-                     "models":  {'repeater': {'backend': 'localhost:50051', 'name': 'repeater'}}}
+        assert response.json() == {
+            "config_sources": {"test-config.yaml": ["repeater"]},
+            "models": {"repeater": {"backend": "localhost:50051", "name": "repeater"}},
+        }
+
 
 def test_config_delete(tmp_path):
     # move test-config.yaml to temp dir
-    os.system('cp tests/fixtures/test-config.yaml {}'.format(str(tmp_path)))
+    os.system("cp tests/fixtures/test-config.yaml {}".format(str(tmp_path)))
     os.environ["LFAI_CONFIG_PATH"] = str(tmp_path)
     with TestClient(app) as client:
         # ensure the API loads the temp config
         response = client.get("/models")
         assert response.status_code == 200
-        assert response.json() == {'config_sources': {'test-config.yaml': ['repeater']},
-                     "models":  {'repeater': {'backend': 'localhost:50051', 'name': 'repeater'}}}
+        assert response.json() == {
+            "config_sources": {"test-config.yaml": ["repeater"]},
+            "models": {"repeater": {"backend": "localhost:50051", "name": "repeater"}},
+        }
         # delete source config from temp dir
-        os.system('rm {}'.format(os.path.join(str(tmp_path),'test-config.yaml')))
+        os.system("rm {}".format(os.path.join(str(tmp_path), "test-config.yaml")))
         # wait for the api to be able to detect the change
         time.sleep(0.5)
         # assert response is now empty
         response = client.get("/models")
         assert response.status_code == 200
-        assert response.json() == {'config_sources': {}, "models":  {}}
+        assert response.json() == {"config_sources": {}, "models": {}}
 
     os.environ["LFAI_CONFIG_PATH"] = os.path.join(os.path.dirname(__file__), "fixtures")
 
 
 def test_routes():
     expected_routes = {
-        "/docs": ['GET', 'HEAD'],
-        "/healthz": ['GET'],
-        "/models": ['GET'],
-        "/openai/v1/completions": ['POST'],
-        "/openai/v1/chat/completions": ['POST'],
-        "/openai/v1/models": ['GET'],
-        "/openai/v1/embeddings": ['POST'],
-        "/openai/v1/audio/transcriptions": ['POST'],
+        "/docs": ["GET", "HEAD"],
+        "/healthz": ["GET"],
+        "/models": ["GET"],
+        "/openai/v1/completions": ["POST"],
+        "/openai/v1/chat/completions": ["POST"],
+        "/openai/v1/models": ["GET"],
+        "/openai/v1/embeddings": ["POST"],
+        "/openai/v1/audio/transcriptions": ["POST"],
     }
 
     actual_routes = app.routes
@@ -69,7 +72,10 @@ def test_healthz():
         assert response.json() == {"status": "ok"}
 
 
-@pytest.mark.skipif(os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true", reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true")
+@pytest.mark.skipif(
+    os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true",
+    reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true",
+)
 def test_completion():
     with TestClient(app) as client:
         # Send request to client
@@ -78,7 +84,9 @@ def test_completion():
             model="repeater",
             prompt=input_text,
         )
-        response = client.post("/openai/v1/completions", json=completion_request.model_dump())
+        response = client.post(
+            "/openai/v1/completions", json=completion_request.model_dump()
+        )
         assert response.status_code == 200
 
         # parse through the response
@@ -94,9 +102,12 @@ def test_completion():
         assert response_choices[0].get("text") == input_text
 
 
-@pytest.mark.skipif(os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true", reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true")
+@pytest.mark.skipif(
+    os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true",
+    reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true",
+)
 def test_embedding():
-    expected_embedding=[0.0 for _ in range(10)]
+    expected_embedding = [0.0 for _ in range(10)]
 
     with TestClient(app) as client:
         # Send request to client
@@ -104,7 +115,9 @@ def test_embedding():
             model="repeater",
             input="This is the embedding input text.",
         )
-        response = client.post("/openai/v1/embeddings", json=embedding_request.model_dump())
+        response = client.post(
+            "/openai/v1/embeddings", json=embedding_request.model_dump()
+        )
         assert response.status_code == 200
 
         # parse through the response
@@ -118,7 +131,10 @@ def test_embedding():
         assert data_obj.get("embedding") == expected_embedding
 
 
-@pytest.mark.skipif(os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true", reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true")
+@pytest.mark.skipif(
+    os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true",
+    reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true",
+)
 def test_stream_completion():
     with TestClient(app) as client:
         # Send request to client
@@ -128,9 +144,13 @@ def test_stream_completion():
             prompt=input_text,
             stream=True,
         )
-        response = client.post("/openai/v1/completions", json=stream_completion_request.model_dump())
+        response = client.post(
+            "/openai/v1/completions", json=stream_completion_request.model_dump()
+        )
         assert response.status_code == 200
-        assert response.headers.get('content-type') == "text/event-stream; charset=utf-8"
+        assert (
+            response.headers.get("content-type") == "text/event-stream; charset=utf-8"
+        )
 
         # parse through the streamed response
         iter_length = 0
@@ -147,28 +167,27 @@ def test_stream_completion():
                     choices = stream_response.get("choices")
                     assert len(choices) == 1
                     assert "text" in choices[0]
-                    assert choices[0].get("text") == input_text 
+                    assert choices[0].get("text") == input_text
                     iter_length += 1
 
         # The repeater only response with 5 messages
         assert iter_length == 5
 
 
-@pytest.mark.skipif(os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true", reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true")
+@pytest.mark.skipif(
+    os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true",
+    reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true",
+)
 def test_chat_completion():
     with TestClient(app) as client:
-
         input_content = "this is the chat completion input."
         chat_completion_request = lfai_types.ChatCompletionRequest(
             model="repeater",
-            messages=[
-                lfai_types.ChatMessage(
-                    role="user",
-                    content=input_content
-                )
-            ],
+            messages=[lfai_types.ChatMessage(role="user", content=input_content)],
         )
-        response = client.post("/openai/v1/chat/completions", json=chat_completion_request.model_dump())
+        response = client.post(
+            "/openai/v1/chat/completions", json=chat_completion_request.model_dump()
+        )
         assert response.status_code == 200
 
         assert response
@@ -187,26 +206,27 @@ def test_chat_completion():
         assert response_choices[0].get("message").get("content") == input_content
 
 
-
-@pytest.mark.skipif(os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true", reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true")
+@pytest.mark.skipif(
+    os.environ.get("LFAI_RUN_REPEATER_TESTS") != "true",
+    reason="LFAI_RUN_REPEATER_TESTS envvar was not set to true",
+)
 def test_stream_chat_completion():
     with TestClient(app) as client:
         input_content = "this is the stream chat completion input."
 
         chat_completion_request = lfai_types.ChatCompletionRequest(
             model="repeater",
-            messages=[
-                lfai_types.ChatMessage(
-                    role="user",
-                    content=input_content
-                )
-            ],
+            messages=[lfai_types.ChatMessage(role="user", content=input_content)],
             stream=True,
         )
 
-        response = client.post("/openai/v1/chat/completions", json=chat_completion_request.model_dump())
+        response = client.post(
+            "/openai/v1/chat/completions", json=chat_completion_request.model_dump()
+        )
         assert response.status_code == 200
-        assert response.headers.get('content-type') == "text/event-stream; charset=utf-8"
+        assert (
+            response.headers.get("content-type") == "text/event-stream; charset=utf-8"
+        )
 
         # parse through the streamed response
         iter_length = 0

--- a/utils/config.py
+++ b/utils/config.py
@@ -22,7 +22,9 @@ class Config:
     models: dict[str, Model] = {}
     config_sources: dict[str, list] = {}
 
-    def __init__(self, models: dict[str, Model] = {}, config_sources: dict[str, list] = {}):
+    def __init__(
+        self, models: dict[str, Model] = {}, config_sources: dict[str, list] = {}
+    ):
         self.models = models
         self.config_sources = config_sources
 
@@ -50,14 +52,16 @@ class Config:
                 unique_new_files = set()
                 unique_deleted_files = set()
                 for change in changes:
-                    if change[0] == Change.deleted: 
+                    if change[0] == Change.deleted:
                         unique_deleted_files.add(os.path.basename(change[1]))
                     else:
                         unique_new_files.add(os.path.basename(change[1]))
 
                 # filter the files to those that match the filename or glob pattern
                 filtered_new_matches = fnmatch.filter(unique_new_files, filename)
-                filtered_deleted_matches = fnmatch.filter(unique_deleted_files, filename)
+                filtered_deleted_matches = fnmatch.filter(
+                    unique_deleted_files, filename
+                )
 
                 # load all the updated config files
                 for match in filtered_new_matches:
@@ -129,6 +133,6 @@ class Config:
         for model_name in self.config_sources[config_file]:
             self.models.pop(model_name)
             print("removed {} from model config".format(model_name))
-        
+
         # clear config once all corresponding models are deleted
         self.config_sources.pop(config_file)

--- a/utils/config.py
+++ b/utils/config.py
@@ -73,7 +73,7 @@ class Config:
 
                 # remove deleted models
                 for match in filtered_deleted_matches:
-                    self.delete_by_config(os.path.join(directory, match))
+                    self.remove_model_by_config(os.path.join(directory, match))
 
     def load_config_file(self, config_path: str):
         # load the config file into the config object
@@ -120,11 +120,14 @@ class Config:
             model_config = Model(name=m["name"], backend=m["backend"])
 
             self.models[m["name"]] = model_config
-            self.config_sources[config_path].append(m["name"])
+            try:
+                self.config_sources[config_path].append(m["name"])
+            except KeyError:
+                self.config_sources[config_path] = [m["name"]]
 
     def remove_model_by_config(self, config_path):
         for model_name in self.config_sources[config_path]:
-            self.model.pop(model_name)
+            self.models.pop(model_name)
             print("removed {} from Model Config".format(model_name))
         
         # clear config once all corresponding models are deleted

--- a/utils/config.py
+++ b/utils/config.py
@@ -48,7 +48,7 @@ class Config:
             async for changes in awatch(directory, recursive=False, step=50):
                 # get two unique lists of files that have been (updated files and deleted files)
                 # (awatch can return duplicates depending on the type of updates that happen)
-                print("Config changes detected: {}".format(changes))
+                logging.info("Config changes detected: {}".format(changes))
                 unique_new_files = set()
                 unique_deleted_files = set()
                 for change in changes:
@@ -75,7 +75,7 @@ class Config:
         # reset the model config on shutdown (so old model configs don't get cached)
         self.models = {}
         self.config_sources = {}
-        print("All models have been removed")
+        logging.info("All models have been removed")
 
     def load_config_file(self, directory: str, config_file: str):
         # load the config file into the config object
@@ -89,13 +89,13 @@ class Config:
                 loaded_artifact = yaml.safe_load(c)
             else:
                 # TODO: Return an error ???
-                print(f"Unsupported file type: {config_path}")
+                logging.error(f"Unsupported file type: {config_path}")
                 return
 
             # parse the object into our config
             self.parse_models(loaded_artifact, config_file)
 
-        print("loaded artifact at {}".format(config_path))
+        logging.info("loaded artifact at {}".format(config_path))
 
         return
 
@@ -127,12 +127,12 @@ class Config:
                 self.config_sources[config_file].append(m["name"])
             except KeyError:
                 self.config_sources[config_file] = [m["name"]]
-            print("added {} to model config".format(m["name"]))
+            logging.info("added {} to model config".format(m["name"]))
 
     def remove_model_by_config(self, config_file):
         for model_name in self.config_sources[config_file]:
             self.models.pop(model_name)
-            print("removed {} from model config".format(model_name))
+            logging.info("removed {} from model config".format(model_name))
 
         # clear config once all corresponding models are deleted
         self.config_sources.pop(config_file)

--- a/utils/config.py
+++ b/utils/config.py
@@ -45,7 +45,7 @@ class Config:
 
         # Watch the directory for changes until the end of time
         while True:
-            async for changes in awatch(directory, recursive=False, step=500):
+            async for changes in awatch(directory, recursive=False, step=50):
                 # get two unique lists of files that have been (updated files and deleted files)
                 # (awatch can return duplicates depending on the type of updates that happen)
                 print("Config changes detected: {}".format(changes))

--- a/utils/config.py
+++ b/utils/config.py
@@ -45,7 +45,7 @@ class Config:
 
         # Watch the directory for changes until the end of time
         while True:
-            async for changes in awatch(directory, recursive=False, step=150):
+            async for changes in awatch(directory, recursive=False, step=500):
                 # get two unique lists of files that have been (updated files and deleted files)
                 # (awatch can return duplicates depending on the type of updates that happen)
                 print("Config changes detected: {}".format(changes))

--- a/utils/config.py
+++ b/utils/config.py
@@ -69,14 +69,15 @@ class Config:
 
                 # load all the updated config files
                 for match in filtered_new_matches:
-                    self.load_config_file(os.path.join(directory, match))
+                    self.load_config_file(directory, match)
 
                 # remove deleted models
                 for match in filtered_deleted_matches:
-                    self.remove_model_by_config(os.path.join(directory, match))
+                    self.remove_model_by_config(match)
 
-    def load_config_file(self, config_path: str):
+    def load_config_file(self, directory: str, config_file: str):
         # load the config file into the config object
+        config_path = os.path.join(directory, config_file)
         with open(config_path) as c:
             # Load the file into a python object
             loaded_artifact = {}
@@ -90,7 +91,7 @@ class Config:
                 return
 
             # parse the object into our config
-            self.parse_models(loaded_artifact, config_path)
+            self.parse_models(loaded_artifact, config_file)
 
         print("loaded artifact at {}".format(config_path))
 
@@ -105,7 +106,7 @@ class Config:
 
         # load all the found config files into the config object
         for config_path in config_files:
-            self.load_config_file(config_path)
+            self.load_config_file(directory, filename)
 
         return
 
@@ -115,20 +116,20 @@ class Config:
         else:
             return None
 
-    def parse_models(self, loaded_artifact, config_path):
+    def parse_models(self, loaded_artifact, config_file):
         for m in loaded_artifact["models"]:
             model_config = Model(name=m["name"], backend=m["backend"])
 
             self.models[m["name"]] = model_config
             try:
-                self.config_sources[config_path].append(m["name"])
+                self.config_sources[config_file].append(m["name"])
             except KeyError:
-                self.config_sources[config_path] = [m["name"]]
+                self.config_sources[config_file] = [m["name"]]
 
-    def remove_model_by_config(self, config_path):
-        for model_name in self.config_sources[config_path]:
+    def remove_model_by_config(self, config_file):
+        for model_name in self.config_sources[config_file]:
             self.models.pop(model_name)
             print("removed {} from Model Config".format(model_name))
         
         # clear config once all corresponding models are deleted
-        self.config_sources.pop(config_path)
+        self.config_sources.pop(config_file)

--- a/utils/config.py
+++ b/utils/config.py
@@ -46,26 +46,18 @@ class Config:
             async for changes in awatch(directory, recursive=False, step=150):
                 # get two unique lists of files that have been (updated files and deleted files)
                 # (awatch can return duplicates depending on the type of updates that happen)
+                print("Config changes detected: {}".format(changes))
                 unique_new_files = set()
                 unique_deleted_files = set()
-                print("total incoming changes: ", changes)
                 for change in changes:
-                    print("type of change detected: {}".format(change[0]))
                     if change[0] == Change.deleted: 
                         unique_deleted_files.add(os.path.basename(change[1]))
                     else:
                         unique_new_files.add(os.path.basename(change[1]))
-                    
-
-                print("unique new files identified: ", unique_new_files)
-                print("unique deleted files identified: ", unique_deleted_files)
 
                 # filter the files to those that match the filename or glob pattern
                 filtered_new_matches = fnmatch.filter(unique_new_files, filename)
                 filtered_deleted_matches = fnmatch.filter(unique_deleted_files, filename)
-                
-                print("new matches to the filename ({}) in question: ".format(filename), filtered_new_matches)
-                print("deleted matches to the filename ({}) in question: ".format(filename), filtered_deleted_matches)
 
                 # load all the updated config files
                 for match in filtered_new_matches:
@@ -74,6 +66,12 @@ class Config:
                 # remove deleted models
                 for match in filtered_deleted_matches:
                     self.remove_model_by_config(match)
+
+    async def clear_all_models(self):
+        # reset the model config on shutdown (so old model configs don't get cached)
+        self.models = {}
+        self.config_sources = {}
+        print("All models have been removed")
 
     def load_config_file(self, directory: str, config_file: str):
         # load the config file into the config object
@@ -125,11 +123,12 @@ class Config:
                 self.config_sources[config_file].append(m["name"])
             except KeyError:
                 self.config_sources[config_file] = [m["name"]]
+            print("added {} to model config".format(m["name"]))
 
     def remove_model_by_config(self, config_file):
         for model_name in self.config_sources[config_file]:
             self.models.pop(model_name)
-            print("removed {} from Model Config".format(model_name))
+            print("removed {} from model config".format(model_name))
         
         # clear config once all corresponding models are deleted
         self.config_sources.pop(config_file)


### PR DESCRIPTION
- Adds a check for config deletions so that models are removed from the Model Config object when the backend is removed.
- Adds relevant tests for this new functionality