### PR TITLE
remove deprecated event decorator

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,9 +35,4 @@ async def models():
     return get_model_config()
 
 
-@app.on_event("startup")
-async def watch_for_configs():
-    asyncio.create_task(get_model_config().watch_and_load_configs())
-
-
 app.include_router(openai_router)


### PR DESCRIPTION
Removes a deprecated decorator that is already handled by the lifespan function.